### PR TITLE
Python bindings: emit exceptions in UseExceptions() mode on failed OpenMDArray(), OpenGroup(), GetAttribute()

### DIFF
--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -60,6 +60,18 @@ def test_mem_md_basic():
     assert not rg.GetAttribute("not existing")
     assert not rg.GetVectorLayerNames()
     assert not rg.OpenVectorLayer("not existing")
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.OpenMDArray("not existing")
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.OpenMDArrayFromFullname("not existing")
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.OpenGroup("not existing")
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.OpenGroupFromFullname("not existing")
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.GetAttribute("not existing")
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.OpenVectorLayer("not existing")
 
 
 def test_mem_md_subgroup():
@@ -91,6 +103,8 @@ def test_mem_md_subgroup():
     array = rg.OpenMDArrayFromFullname('/subgroup/myarray')
     assert array is not None
     assert array.GetFullName() == '/subgroup/myarray'
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        array.GetAttribute("not existing")
 
     copy_ds = drv.CreateCopy('', ds)
     assert copy_ds
@@ -1827,6 +1841,8 @@ def test_mem_md_array_resolvemdarray():
     b.CreateMDArray("var_c", [], gdal.ExtendedDataType.Create(gdal.GDT_Int16))
 
     assert rg.ResolveMDArray("x", "/") is None
+    with gdaltest.enable_exceptions(), pytest.raises(Exception):
+        rg.ResolveMDArray("x", "/")
 
     assert rg.ResolveMDArray("/a/var_a", "/").GetFullName() == "/a/var_a"
     assert rg.ResolveMDArray("var_a", "/").GetFullName() == "/a/var_a"

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -69,17 +69,41 @@ public:
 
 %newobject OpenMDArray;
   GDALMDArrayHS* OpenMDArray( const char* name, char** options = 0) {
-    return GDALGroupOpenMDArray(self, name, options);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALMDArrayH hRet = GDALGroupOpenMDArray(self, name, options);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Array %s does not exist", name);
+#endif
+    return hRet;
   }
 
 %newobject OpenMDArrayFromFullname;
   GDALMDArrayHS* OpenMDArrayFromFullname( const char* name, char** options = 0) {
-    return GDALGroupOpenMDArrayFromFullname(self, name, options);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALMDArrayH hRet = GDALGroupOpenMDArrayFromFullname(self, name, options);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Array %s does not exist", name);
+#endif
+    return hRet;
   }
 
 %newobject ResolveMDArray;
   GDALMDArrayHS* ResolveMDArray( const char* name, const char* starting_point, char** options = 0) {
-    return GDALGroupResolveMDArray(self, name, starting_point, options);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALMDArrayH hRet = GDALGroupResolveMDArray(self, name, starting_point, options);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Array %s does not exist", name);
+#endif
+    return hRet;
   }
 
 %apply (char **CSL) {char **};
@@ -90,12 +114,28 @@ public:
 
 %newobject OpenGroup;
   GDALGroupHS* OpenGroup( const char* name, char** options = 0) {
-    return GDALGroupOpenGroup(self, name, options);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALGroupH hRet = GDALGroupOpenGroup(self, name, options);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Group %s does not exist", name);
+#endif
+    return hRet;
   }
 
 %newobject OpenGroupFromFullname;
   GDALGroupHS* OpenGroupFromFullname( const char* name, char** options = 0) {
-    return GDALGroupOpenGroupFromFullname(self, name, options);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALGroupH hRet = GDALGroupOpenGroupFromFullname(self, name, options);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Group %s does not exist", name);
+#endif
+    return hRet;
   }
 
 %apply (char **CSL) {char **};
@@ -105,7 +145,15 @@ public:
 %clear char **;
 
   OGRLayerShadow* OpenVectorLayer( const char* name, char** options = 0) {
-    return (OGRLayerShadow*) GDALGroupOpenVectorLayer(self, name, options);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    OGRLayerH hRet = GDALGroupOpenVectorLayer(self, name, options);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Vector layer %s does not exist", name);
+#endif
+    return (OGRLayerShadow*) hRet;
   }
 
 #if defined(SWIGPYTHON)
@@ -116,7 +164,15 @@ public:
 
 %newobject GetAttribute;
   GDALAttributeHS* GetAttribute( const char* name) {
-    return GDALGroupGetAttribute(self, name);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALAttributeH hRet = GDALGroupGetAttribute(self, name);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Attribute %s does not exist", name);
+#endif
+    return hRet;
   }
 
 #if defined(SWIGPYTHON)
@@ -749,7 +805,15 @@ public:
 
 %newobject GetAttribute;
   GDALAttributeHS* GetAttribute( const char* name) {
-    return GDALMDArrayGetAttribute(self, name);
+#if defined(SWIGPYTHON)
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+#endif
+    GDALAttributeH hRet = GDALMDArrayGetAttribute(self, name);
+#if defined(SWIGPYTHON)
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Attribute %s does not exist", name);
+#endif
+    return hRet;
   }
 
 #if defined(SWIGPYTHON)

--- a/swig/python/extensions/gdal_wrap.cpp
+++ b/swig/python/extensions/gdal_wrap.cpp
@@ -5203,34 +5203,90 @@ SWIGINTERN char **GDALGroupHS_GetMDArrayNames(GDALGroupHS *self,char **options=0
     return GDALGroupGetMDArrayNames( self, options );
   }
 SWIGINTERN GDALMDArrayHS *GDALGroupHS_OpenMDArray(GDALGroupHS *self,char const *name,char **options=0){
-    return GDALGroupOpenMDArray(self, name, options);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALMDArrayH hRet = GDALGroupOpenMDArray(self, name, options);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Array %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN GDALMDArrayHS *GDALGroupHS_OpenMDArrayFromFullname(GDALGroupHS *self,char const *name,char **options=0){
-    return GDALGroupOpenMDArrayFromFullname(self, name, options);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALMDArrayH hRet = GDALGroupOpenMDArrayFromFullname(self, name, options);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Array %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN GDALMDArrayHS *GDALGroupHS_ResolveMDArray(GDALGroupHS *self,char const *name,char const *starting_point,char **options=0){
-    return GDALGroupResolveMDArray(self, name, starting_point, options);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALMDArrayH hRet = GDALGroupResolveMDArray(self, name, starting_point, options);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Array %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN char **GDALGroupHS_GetGroupNames(GDALGroupHS *self,char **options=0){
     return GDALGroupGetGroupNames( self, options );
   }
 SWIGINTERN GDALGroupHS *GDALGroupHS_OpenGroup(GDALGroupHS *self,char const *name,char **options=0){
-    return GDALGroupOpenGroup(self, name, options);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALGroupH hRet = GDALGroupOpenGroup(self, name, options);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Group %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN GDALGroupHS *GDALGroupHS_OpenGroupFromFullname(GDALGroupHS *self,char const *name,char **options=0){
-    return GDALGroupOpenGroupFromFullname(self, name, options);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALGroupH hRet = GDALGroupOpenGroupFromFullname(self, name, options);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Group %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN char **GDALGroupHS_GetVectorLayerNames(GDALGroupHS *self,char **options=0){
     return GDALGroupGetVectorLayerNames( self, options );
   }
 SWIGINTERN OGRLayerShadow *GDALGroupHS_OpenVectorLayer(GDALGroupHS *self,char const *name,char **options=0){
-    return (OGRLayerShadow*) GDALGroupOpenVectorLayer(self, name, options);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    OGRLayerH hRet = GDALGroupOpenVectorLayer(self, name, options);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Vector layer %s does not exist", name);
+
+    return (OGRLayerShadow*) hRet;
   }
 SWIGINTERN void GDALGroupHS_GetDimensions(GDALGroupHS *self,GDALDimensionHS ***pdims,size_t *pnCount,char **options=0){
     *pdims = GDALGroupGetDimensions(self, pnCount, options);
   }
 SWIGINTERN GDALAttributeHS *GDALGroupHS_GetAttribute(GDALGroupHS *self,char const *name){
-    return GDALGroupGetAttribute(self, name);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALAttributeH hRet = GDALGroupGetAttribute(self, name);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Attribute %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN void GDALGroupHS_GetAttributes(GDALGroupHS *self,GDALAttributeHS ***pattrs,size_t *pnCount,char **options=0){
     *pattrs = GDALGroupGetAttributes(self, pnCount, options);
@@ -5753,7 +5809,15 @@ SWIGINTERN CPLErr GDALMDArrayHS_AdviseRead(GDALMDArrayHS *self,int nDims1,GUIntB
     return CE_None;
   }
 SWIGINTERN GDALAttributeHS *GDALMDArrayHS_GetAttribute(GDALMDArrayHS *self,char const *name){
-    return GDALMDArrayGetAttribute(self, name);
+
+    CPLErr eLastErrorType = CPLGetLastErrorType();
+
+    GDALAttributeH hRet = GDALMDArrayGetAttribute(self, name);
+
+    if( bUseExceptions && hRet == NULL && eLastErrorType == CE_None && CPLGetLastErrorType() == CE_None )
+        CPLError(CE_Failure, CPLE_AppDefined, "Attribute %s does not exist", name);
+
+    return hRet;
   }
 SWIGINTERN void GDALMDArrayHS_GetAttributes(GDALMDArrayHS *self,GDALAttributeHS ***pattrs,size_t *pnCount,char **options=0){
     *pattrs = GDALMDArrayGetAttributes(self, pnCount, options);


### PR DESCRIPTION
Port fix that just landed in official release/3.5 branch for https://hello.planet.com/jira/browse/PE-49162 